### PR TITLE
GitHub Actions Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Install DEB Packages
+        run: sudo apt-get install llvm
+
+      - name: Build
+        run: make all
+
+      - name: Test
+        run: make test


### PR DESCRIPTION
Let's add a basic CI process. 
Two tests are failing:

```
1) GroupSigner - auto
      errors:

     AssertionError: expected [Function] to throw error including 'seed too small' but got 'input data must be uint8array'
     + expected - actual

     -input data must be uint8array
     +seed too small
     
     at Context.<anonymous> (/home/runner/work/anonymous-credentials/anonymous-credentials/tests/tests.js:172:59)
     at callFn (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runnable.js:387:21)
     at Test.Runnable.run (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runnable.js:379:7)
     at Runner.runTest (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:535:10)
     at /home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:653:12
     at next (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:447:14)
     at /home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:457:7
     at next (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:362:14)
     at Immediate._onImmediate (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:425:5)
     at processImmediate (internal/timers.js:461:21)

 2) GroupSigner - native
      errors:

     AssertionError: expected [Function] to throw error including 'seed too small' but got 'input data must be uint8array'
     + expected - actual

     -input data must be uint8array
     +seed too small
     
     at Context.<anonymous> (/home/runner/work/anonymous-credentials/anonymous-credentials/tests/tests.js:172:59)
     at callFn (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runnable.js:387:21)
     at Test.Runnable.run (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runnable.js:379:7)
     at Runner.runTest (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:535:10)
     at /home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:653:12
     at next (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:447:14)
     at /home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:457:7
     at next (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:362:14)
     at Immediate._onImmediate (/home/runner/work/anonymous-credentials/anonymous-credentials/node_modules/mocha/lib/runner.js:425:5)
     at processImmediate (internal/timers.js:461:21)
```